### PR TITLE
Hide Survey for existing patients

### DIFF
--- a/app/assets/javascripts/mom.checkin.js
+++ b/app/assets/javascripts/mom.checkin.js
@@ -154,6 +154,8 @@ MoM.Checkin.hacks = function(){
         MoM.Checkin.useTextDate();
 
         $('form.new_patient').show();
+        $('#bottom_demographics_next').hide();
+        $('#bottom_demographics_submit').show();
         $('#reprint').hide();
         $('#previous-patient').hide();
         $('#waiver_agree_button').focus();

--- a/app/views/patients/new.html.haml
+++ b/app/views/patients/new.html.haml
@@ -38,8 +38,10 @@
   %div.input-bottom.check_out
     %span.left
       = link_to_reset new_patient_path
+
     #bottom_demographics
-      %button Next
+      %button#bottom_demographics_next Next
+      = f.submit "Check In", :id => "bottom_demographics_submit"
     #bottom_survey{:style=>"display:none;"}
       = f.submit "Check In"
       = link_to "Back", "#", :class => 'back'


### PR DESCRIPTION
Fixes #1. When the Ajax call retrieves a patient, it hides the Next button and shows a Check In button instead.
