### PR TITLE
Fix treatment area association caching issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,4 +31,5 @@ group :test do
   gem 'database_cleaner', '~> 0.7.1'
   gem 'capybara-webkit'
   gem 'turn'
+  gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     thor (0.14.6)
     tilt (1.3.3)
+    timecop (0.5.2)
     treetop (1.4.10)
       polyglot
       polyglot (>= 0.3.1)
@@ -179,6 +180,7 @@ DEPENDENCIES
   rails_setup
   rubyzip
   sass-rails (~> 3.1.0)
+  timecop
   turn
   uglifier
   will_paginate (~> 3.0.2)

--- a/test/unit/treatment_area_test.rb
+++ b/test/unit/treatment_area_test.rb
@@ -29,13 +29,17 @@ class TreatmentAreaTest < ActiveSupport::TestCase
     area = FactoryGirl.create(:treatment_area)
     p1 = FactoryGirl.create(:patient)
     p2 = FactoryGirl.create(:patient)
-    p3 = FactoryGirl.create(:patient)
 
-    [p1, p2, p3].each { |p| p.assign(area.id, false) }
-
-    p1.assignments.first.update_attribute(:created_at, Time.now - 2.days)
+    [p1, p2].each { |p| p.assign(area.id, false) }
 
     assert_equal 2, area.patients.count
+
+    Timecop.travel(2.days.from_now) do
+      p3 = FactoryGirl.create(:patient)
+      p3.assign(area.id, false)
+
+      assert_equal 1, area.patients(true).count
+    end
   end
 
   def test_should_properly_count_current_capacity


### PR DESCRIPTION
Addresses issue #28
- Use a proc for patients association conditions attribute
- Convert time to UTC for patients association condition parameters
- Force reload of the patients association when invoking it
